### PR TITLE
fix for #502

### DIFF
--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,5 +1,6 @@
 import Container from '@components/Container';
 import CustomErrorBoundary from '@components/CustomErrorBoundary';
+import useWakeLock from '@hooks/useWakeLock';
 import AnimatorView from '@views/Animator';
 import ExportView from '@views/Export';
 import HomeView from '@views/Home';
@@ -8,22 +9,27 @@ import ShortcutsView from '@views/Shortcuts';
 import SyncListView from '@views/SyncList';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
 
-const App = () => (
-  <CustomErrorBoundary>
-    <Container>
-      <Router>
-        <Routes>
-          <Route exact path="/" element={<HomeView />} />
-          <Route exact path="/settings" element={<SettingsView />} />
-          <Route exact path="/shortcuts" element={<ShortcutsView />} />
-          <Route exact path="/animator/:id/:track" element={<AnimatorView />} />
-          <Route exact path="/export/:id/:track" element={<ExportView />} />
-          <Route exact path="/sync-list" element={<SyncListView />} />
-          <Route path="*" element={null} />
-        </Routes>
-      </Router>
-    </Container>
-  </CustomErrorBoundary>
-);
+const App = () => {
+  // Keep the screen awake while the app is open
+  useWakeLock();
+
+  return (
+    <CustomErrorBoundary>
+      <Container>
+        <Router>
+          <Routes>
+            <Route exact path="/" element={<HomeView />} />
+            <Route exact path="/settings" element={<SettingsView />} />
+            <Route exact path="/shortcuts" element={<ShortcutsView />} />
+            <Route exact path="/animator/:id/:track" element={<AnimatorView />} />
+            <Route exact path="/export/:id/:track" element={<ExportView />} />
+            <Route exact path="/sync-list" element={<SyncListView />} />
+            <Route path="*" element={null} />
+          </Routes>
+        </Router>
+      </Container>
+    </CustomErrorBoundary>
+  );
+};
 
 export default App;

--- a/src/renderer/components/GridRatioPreview/index.jsx
+++ b/src/renderer/components/GridRatioPreview/index.jsx
@@ -3,7 +3,7 @@ import RatioBorders from '@components/RatioBorders';
 
 import * as style from './style.module.css';
 
-const CANVAS_WIDTH = 260;
+const CANVAS_WIDTH = 175;
 const CANVAS_HEIGHT = 130;
 const RATIO = 4 / 3;
 

--- a/src/renderer/components/GridRatioPreview/style.module.css
+++ b/src/renderer/components/GridRatioPreview/style.module.css
@@ -4,7 +4,7 @@
   border: solid 1px var(--color-theme-light);
   border-radius: var(--border-radius-medium);
   display: block;
-  max-width: 360px;
+  max-width: 100px;
   overflow: hidden;
   position: relative;
   width: 100%;

--- a/src/renderer/hooks/useWakeLock.js
+++ b/src/renderer/hooks/useWakeLock.js
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+function useWakeLock() {
+  useEffect(() => {
+    if (!('wakeLock' in navigator)) {
+      return;
+    }
+
+    let active = true;
+    let wakeLock = null;
+
+    const requestWakeLock = async () => {
+      try {
+        const lock = await navigator.wakeLock.request('screen');
+        if (active) {
+          wakeLock = lock;
+        } else {
+          lock.release().catch(() => {});
+        }
+      } catch (err) {} // eslint-disable-line no-empty
+    };
+
+    // The wake lock is automatically released when the page is hidden, re-request it when visible again
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        requestWakeLock();
+      }
+    };
+
+    requestWakeLock();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      active = false;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      wakeLock?.release().catch(() => {});
+    };
+  }, []);
+}
+
+export default useWakeLock;


### PR DESCRIPTION
Simple implementation of [Screen Wake Lock](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) to prevent system from going to sleep. 
System stays on if page is visible/app not minimized.
If not visible/minimized: system sleeps.  
Tested on Windows

Additional small change to resize grid preview in settings (personal preference, not necessary)